### PR TITLE
Improve text contrast in calculator UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,24 @@
   <title>Mileage → Cost Calculator</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    :root { --card-max: 960px; }
+    :root {
+      --card-max: 960px;
+      --bs-body-color: #e6eaf2;
+      --bs-body-bg: #0b1220;
+      --bs-link-color: #9db0de;
+      --bs-link-hover-color: #cdd7f4;
+      --bs-card-color: #e6eaf2;
+    }
     body { background: #0b1220; color: #e6eaf2; }
     .navbar { background: linear-gradient(90deg, #0e1730, #151e38); }
-    .card { background: #11182b; border: 1px solid #1b2748; box-shadow: 0 10px 30px rgba(0,0,0,.25); }
+    .card { background: #11182b; border: 1px solid #1b2748; box-shadow: 0 10px 30px rgba(0,0,0,.25); color:#e6eaf2; }
     .form-control, .form-select { background:#0e1630; color:#e6eaf2; border-color:#243154; }
     .form-control:focus, .form-select:focus { box-shadow: 0 0 0 .2rem rgba(99,102,241,.35); border-color:#6366f1; }
+    .form-control::placeholder { color:#8ea0c8; }
     .input-group-text { background:#0d1530; color:#b9c3e1; border-color:#243154; }
     .link-muted { color:#9db0de; }
     .muted { color:#8ea0c8; }
+    .form-check-label, summary { color:#cdd7f4; }
     .unit-toggle .btn { border-color:#243154; color:#cdd7f4; }
     .unit-toggle .btn.active { background:#2a3460; color:#fff; }
     .result-badge { font-size: .9rem; }


### PR DESCRIPTION
## Summary
- tune the global Bootstrap color variables so text renders with light contrast on the dark theme
- update card, placeholder, and form label colors to remain readable across controls

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de853fd35c8322b1737433dbd3a284