### PR TITLE
Set text colors to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@
   <style>
     :root {
       --card-max: 960px;
-      --bs-body-color: #e6eaf2;
+      --bs-body-color: #ffffff;
       --bs-body-bg: #0b1220;
       --bs-link-color: #9db0de;
       --bs-link-hover-color: #cdd7f4;
-      --bs-card-color: #e6eaf2;
+      --bs-card-color: #ffffff;
     }
-    body { background: #0b1220; color: #e6eaf2; }
+    body { background: #0b1220; color: #ffffff; }
     .navbar { background: linear-gradient(90deg, #0e1730, #151e38); }
-    .card { background: #11182b; border: 1px solid #1b2748; box-shadow: 0 10px 30px rgba(0,0,0,.25); color:#e6eaf2; }
-    .form-control, .form-select { background:#0e1630; color:#e6eaf2; border-color:#243154; }
+    .card { background: #11182b; border: 1px solid #1b2748; box-shadow: 0 10px 30px rgba(0,0,0,.25); color:#ffffff; }
+    .form-control, .form-select { background:#0e1630; color:#ffffff; border-color:#243154; }
     .form-control:focus, .form-select:focus { box-shadow: 0 0 0 .2rem rgba(99,102,241,.35); border-color:#6366f1; }
     .form-control::placeholder { color:#8ea0c8; }
     .input-group-text { background:#0d1530; color:#b9c3e1; border-color:#243154; }


### PR DESCRIPTION
## Summary
- update the calculator theme to use pure white typography for improved contrast across the interface

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de86a45bfc83229611848f45cf28b4